### PR TITLE
Fix arXiv URL and add HTTPS test

### DIFF
--- a/digital_literacy/source_evaluator.py
+++ b/digital_literacy/source_evaluator.py
@@ -278,7 +278,7 @@ class SourceEvaluator:
         log.info(f"\n{Colors.BLUE}{Colors.BOLD}--- Initiating Academic Search for '{query}' on {api_type.upper()} ---{Colors.RESET}")
         results = []
         if api_type == "arxiv":
-            arxiv_url = f"http://export.arxiv.org/api/query?search_query=all:{query}&start=0&max_results=5"
+            arxiv_url = f"https://export.arxiv.org/api/query?search_query=all:{query}&start=0&max_results=5"
             log.info(f"{Colors.DIM}  Querying arXiv: {arxiv_url}{Colors.RESET}")
             try:
                 response = requests.get(arxiv_url, timeout=15)

--- a/tests/test_search_academic_api.py
+++ b/tests/test_search_academic_api.py
@@ -1,0 +1,28 @@
+import types
+import torch
+from digital_literacy import source_evaluator
+
+
+def test_search_academic_api_uses_https(monkeypatch):
+    called_urls = []
+
+    def dummy_init(self, device="cpu"):
+        self.device = torch.device(device)
+
+    def fake_get(url, timeout=15):
+        called_urls.append(url)
+        return types.SimpleNamespace(text="<feed></feed>", raise_for_status=lambda: None)
+
+    class DummySoup:
+        def find_all(self, *a, **k):
+            return []
+
+    monkeypatch.setattr(source_evaluator.SourceEvaluator, "__init__", dummy_init)
+    monkeypatch.setattr(source_evaluator.requests, "get", fake_get)
+    monkeypatch.setattr(source_evaluator, "BeautifulSoup", lambda *a, **k: DummySoup())
+
+    se = source_evaluator.SourceEvaluator(device="cpu")
+    se.search_academic_api("test", api_type="arxiv")
+
+    assert called_urls
+    assert called_urls[0].startswith("https://export.arxiv.org")

--- a/ultimate_workflow.py
+++ b/ultimate_workflow.py
@@ -111,7 +111,7 @@ def main() -> None:
         resp = requests.get("http://127.0.0.1:5000/notes/demo", timeout=1)
         if resp.ok:
             print("Collaboration server notes:", resp.json())
-    except Exception as exc:  # pragma: no cover - server typically not running
+    except requests.exceptions.RequestException as exc:  # pragma: no cover - server typically not running
         print("Could not reach collaboration server:", exc)
 
 


### PR DESCRIPTION
## Summary
- switch arXiv query URL to https
- handle requests connection errors explicitly in `ultimate_workflow`
- add unit test covering URL construction

## Testing
- `pytest tests/test_search_academic_api.py -q`
- `pytest -q` *(fails: 7 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6879d69eb5388331aecb8c1775e48c20