### PR TITLE
Add frontend assets and ambient audio hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,7 @@ without a GPU.
 
 ## License
 This repository is provided for research and experimentation purposes only.
+
+## Frontend Assets and Ambient Audio
+The `webapp/` directory contains optional web assets used in browser-based demos. `manifest.webmanifest` references a custom SVG icon, and `animated-favicon.svg` provides a simple animated favicon. The example hook in `useAmbientAudio.ts` plays looping background audio while gracefully handling decoding errors that can occur with unsupported files.
+

--- a/webapp/animated-favicon.svg
+++ b/webapp/animated-favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle id="outer" cx="50" cy="50" r="45" fill="#1e1e1e" stroke="#a855f7" stroke-width="3"/>
+  <circle id="inner" cx="50" cy="50" r="30" fill="#a855f7">
+    <animate attributeName="r" values="25;30;25" dur="3s" repeatCount="indefinite" />
+  </circle>
+</svg>

--- a/webapp/manifest.webmanifest
+++ b/webapp/manifest.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "NeuroFlux App",
+  "short_name": "NeuroFlux",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#7e22ce",
+  "icons": [
+    {
+      "src": "neuroflux-icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/webapp/neuroflux-icon.svg
+++ b/webapp/neuroflux-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7e22ce"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <circle cx="50" cy="50" r="48" fill="url(#grad)"/>
+  <path d="M30 50a20 20 0 1 1 40 0 20 20 0 1 1-40 0z" fill="#fff"/>
+</svg>

--- a/webapp/useAmbientAudio.ts
+++ b/webapp/useAmbientAudio.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Simple hook to play looping ambient audio with graceful failure handling.
+ * Errors from decoding are caught to avoid "Unable to decode audio data".
+ */
+export function useAmbientAudio(url: string, volume = 0.5) {
+  const audioCtxRef = useRef<AudioContext>();
+  const sourceRef = useRef<AudioBufferSourceNode>();
+
+  useEffect(() => {
+    const ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    audioCtxRef.current = ctx;
+
+    fetch(url)
+      .then(resp => resp.arrayBuffer())
+      .then(data => ctx.decodeAudioData(data))
+      .then(buffer => {
+        const src = ctx.createBufferSource();
+        src.buffer = buffer;
+        src.loop = true;
+        const gain = ctx.createGain();
+        gain.gain.value = volume;
+        src.connect(gain).connect(ctx.destination);
+        src.start(0);
+        sourceRef.current = src;
+      })
+      .catch(err => {
+        console.error('Failed to start ambient audio', err);
+      });
+
+    return () => {
+      sourceRef.current?.stop();
+      ctx.close();
+    };
+  }, [url, volume]);
+}


### PR DESCRIPTION
## Summary
- add sample web assets including animated SVG icons
- provide a manifest referencing the new icon
- add `useAmbientAudio` hook with improved decoding error handling
- document new frontend assets in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6879dd2b18588331bcfb5543bfd3e5f7