### PR TITLE
Implement LMDB cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ pillow
 pyyaml
 tqdm
 torchvision
+lmdb
+msgpack

--- a/tests/test_lmdb_cache.py
+++ b/tests/test_lmdb_cache.py
@@ -1,0 +1,13 @@
+import torch
+from multimodal_dataset_manager import LMDBCache
+
+
+def test_lmdb_cache_roundtrip(tmp_path):
+    cache = LMDBCache(tmp_path / "db")
+    tensor = torch.arange(5)
+    cache.put("a", tensor)
+    loaded = cache.get("a")
+    assert loaded is not None
+    assert torch.equal(loaded, tensor)
+    cache.close()
+


### PR DESCRIPTION
## Summary
- add an `LMDBCache` helper class for tensor caching
- add msgpack/lmdb dependencies
- test LMDBCache basic usage

## Testing
- `pytest tests/test_lmdb_cache.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'skopt')*

------
https://chatgpt.com/codex/tasks/task_e_6879deb788388331ad48a46dea9bdee2