### PR TITLE
Improve test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,12 @@ print(best)
 
 ## Running Tests
 Run the unit tests with `pytest` from the repository root after installing the
-development requirements:
+standard and development requirements. Both files must be installed or
+`pytest` will raise import errors during collection:
 
 ```bash
 source .venv/bin/activate  # if not already active
+pip install -r requirements.txt
 pip install -r requirements-dev.txt
 pytest
 ```


### PR DESCRIPTION
## Summary
- clarify that `requirements.txt` must be installed along with `requirements-dev.txt` before running `pytest`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6879ec7d8b288331a72fbb86e3615093