### PR TITLE
Add configuration file and settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ To start the collaboration server used for peer collaboration, run the following
 python3 peer_collab/collaboration_server.py
 ```
 
+## Configuration
+Default settings such as the data directory, model embedding dimension and
+memory budget live in `config.yaml`. `main.py` loads this file automatically.
+Provide a different file with the `--config` option:
+
+```bash
+python3 main.py --config my_config.yaml
+```
+
 ## Module Walkthrough
 The example workflow in `main.py` demonstrates how each component fits together.
 The script performs the following steps:

--- a/RealTimeDataAbsorber.py
+++ b/RealTimeDataAbsorber.py
@@ -540,14 +540,27 @@ class AdaptiveNeuralNetwork(nn.Module):
 
 class RealTimeDataAbsorber:
     """Main class for real-time data absorption and learning"""
-    
-    def __init__(self, 
+
+    def __init__(self,
                  model_config: Dict[str, Any],
+                 settings: Optional[Dict[str, Any]] = None,
                  learning_rate: float = 1e-4,
                  buffer_size: int = 10000,
                  batch_size: int = 32,
                  update_frequency: int = 100,
                  adaptation_threshold: float = 0.7):
+
+        if settings:
+            learning_rate = settings.get("learning_rate", learning_rate)
+            buffer_size = settings.get("buffer_size", buffer_size)
+            batch_size = settings.get("batch_size", batch_size)
+            update_frequency = settings.get("update_frequency", update_frequency)
+            adaptation_threshold = settings.get(
+                "adaptation_threshold", adaptation_threshold
+            )
+            self.db_path = settings.get("db_path", "realtime_learning.db")
+        else:
+            self.db_path = "realtime_learning.db"
         
         # Configuration
         self.learning_rate = learning_rate
@@ -593,7 +606,6 @@ class RealTimeDataAbsorber:
         }
         
         # Database for persistence
-        self.db_path = "realtime_learning.db"
         self._init_database()
         
         logging.info("RealTimeDataAbsorber initialized")

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+data_root: "./data"
+model:
+  embed_dim: 256
+  learning_rate: 0.0001
+memory_budget: 50000

--- a/correlation_rag_module.py
+++ b/correlation_rag_module.py
@@ -22,13 +22,29 @@ class CorrelationRAGMemory:
     """
 
     def __init__(self,
-                 emb_dim: int,
+                 emb_dim: Optional[int] = None,
                  memory_budget: int = 50_000,
-                 device: str = "cuda" if torch.cuda.is_available() else "cpu",
+                 device: Optional[str] = None,
                  pq_m: int = 16,
                  hnsw_m: int = 32,
                  l2_norm: bool = True,
-                 save_path: str = "corr_rag.mem"):
+                 save_path: str = "corr_rag.mem",
+                 settings: Optional[Dict[str, Any]] = None):
+
+        if settings:
+            emb_dim = settings.get("embed_dim", emb_dim)
+            memory_budget = settings.get("memory_budget", memory_budget)
+            device = settings.get("device", device)
+            pq_m = settings.get("pq_m", pq_m)
+            hnsw_m = settings.get("hnsw_m", hnsw_m)
+            l2_norm = settings.get("l2_norm", l2_norm)
+            save_path = settings.get("save_path", save_path)
+
+        if emb_dim is None:
+            raise ValueError("embed_dim must be provided via argument or settings")
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+
         self.emb_dim        = emb_dim
         self.memory_budget  = memory_budget
         self.device         = device

--- a/main.py
+++ b/main.py
@@ -1,7 +1,15 @@
 
 """Entry point demonstrating the various SelfResearch modules."""
 
+import argparse
+import yaml
 import torch
+
+
+def load_config(path: str) -> dict:
+    """Load a YAML configuration file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
 
 from research_workflow.topic_selector import TopicSelector
 from digital_literacy.source_evaluator import SourceEvaluator
@@ -12,7 +20,16 @@ from security.auth_and_ethics import AuthAndEthics
 from data.dataset_loader import load_and_tokenize
 from train.trainer import TrainingConfig, train_model
 
-def main():
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run the SelfResearch demo")
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to YAML configuration"
+    )
+    args = parser.parse_args(argv)
+
+    settings = load_config(args.config)
+    print(f"Loaded config from {args.config}: {settings}")
+
     # Determine device (CUDA or CPU)
     if torch.cuda.is_available():
         device = 'cuda'


### PR DESCRIPTION
## Summary
- load YAML config in `main.py` and expose `--config` argument
- let `RealTimeDataAbsorber` and `CorrelationRAGMemory` accept settings dicts
- provide default `config.yaml`
- document configuration override in README

## Testing
- `pytest tests/test_training_config.py -q` *(fails: ImportError cannot import name 'PreTrainedModel' from 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687a7af1221083319713ab20e68cd8c9