### PR TITLE
Pin stable torch release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-torch==2.7.1+cpu
+torch==2.1.1+cpu
 datasets
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.7.1+cpu
+torch==2.1.1+cpu
 transformers
 scikit-learn
 flask


### PR DESCRIPTION
## Summary
- replace `torch==2.7.1+cpu` with `torch==2.1.1+cpu` in both requirements files

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for torch==2.1.1+cpu)*
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687b395de8708331b9d58f9ece425f5b