### PR TITLE
Add Omni prompt optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ best = unified.optimize_prompt("Write a summary")
 print(best)
 ```
 
+### Omni Prompt Optimization
+
+`OmniPromptOptimizer` fuses **all** prompt optimizers, including Bayesian search
+and soft prompt tuning, to aggressively explore the search space before
+returning the top prompt.
+
+```python
+from analysis.omni_prompt_optimizer import OmniPromptOptimizer
+
+omni = OmniPromptOptimizer("distilgpt2")
+best = omni.optimize_prompt("Write a summary")
+print(best)
+```
+
 
 ## Running Tests
 Run the unit tests with `pytest` from the repository root after installing the

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -11,3 +11,4 @@ from .prompt_bayes_optimizer import BayesianPromptOptimizer
 from .meta_prompt_optimizer import MetaPromptOptimizer
 from .prompt_embedding_tuner import PromptEmbeddingTuner
 from .unified_prompt_optimizer import UnifiedPromptOptimizer
+from .omni_prompt_optimizer import OmniPromptOptimizer

--- a/analysis/omni_prompt_optimizer.py
+++ b/analysis/omni_prompt_optimizer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Omni prompt optimizer combining every strategy."""
+
+from typing import Optional, List
+
+from .prompt_optimizer import PromptOptimizer
+from .advanced_prompt_optimizer import AdvancedPromptOptimizer
+from .prompt_bandit_optimizer import PromptBanditOptimizer
+from .prompt_annealing_optimizer import PromptAnnealingOptimizer
+from .prompt_rl_optimizer import PromptRLOptimizer
+from .prompt_bayes_optimizer import BayesianPromptOptimizer
+from .prompt_evolver import PromptEvolver
+from .prompt_embedding_tuner import PromptEmbeddingTuner
+
+
+class OmniPromptOptimizer(PromptOptimizer):
+    """Fuse all prompt optimizers and select the best result."""
+
+    def __init__(self, model_name: str, *, device: Optional[str] = None) -> None:
+        super().__init__(model_name, device=device)
+        self.advanced = AdvancedPromptOptimizer(model_name, device=self.device.type)
+        self.bandit = PromptBanditOptimizer(
+            model_name,
+            reward_fn=lambda p: -self.score_prompt(p),
+            device=self.device.type,
+            iterations=3,
+            epsilon=0.2,
+        )
+        self.annealer = PromptAnnealingOptimizer(
+            model_name,
+            device=self.device.type,
+            steps=3,
+            temperature=1.0,
+            cooling=0.8,
+        )
+        self.rl = PromptRLOptimizer(
+            model_name,
+            reward_fn=lambda p: -self.score_prompt(p),
+            device=self.device.type,
+            episodes=3,
+            epsilon=0.2,
+            lr=0.3,
+        )
+        self.bayes = BayesianPromptOptimizer(
+            model_name,
+            device=self.device.type,
+            iterations=3,
+        )
+        self.evolver = PromptEvolver(model_name, device=self.device.type)
+        self.tuner = PromptEmbeddingTuner(model_name, prompt_length=5, device=self.device.type)
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        candidates: List[str] = [base_prompt]
+        for opt in (
+            self.advanced,
+            self.bandit,
+            self.annealer,
+            self.rl,
+            self.bayes,
+        ):
+            try:
+                base_prompt = opt.optimize_prompt(base_prompt, n_variations=n_variations)
+                candidates.append(base_prompt)
+            except Exception:
+                pass
+
+        try:
+            evolved = self.evolver.evolve_prompt(base_prompt, generations=2, population_size=n_variations)
+            candidates.append(evolved)
+        except Exception:
+            pass
+
+        try:
+            self.tuner.tune(base_prompt, steps=1)
+            tokens = " ".join(self.tuner.get_prompt_tokens())
+            candidates.append(f"{tokens} {base_prompt}")
+        except Exception:
+            pass
+
+        return min(candidates, key=self.score_prompt)

--- a/tests/test_omni_prompt_optimizer.py
+++ b/tests/test_omni_prompt_optimizer.py
@@ -1,0 +1,18 @@
+from analysis.omni_prompt_optimizer import OmniPromptOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_omni_optimize_prompt():
+    omni = OmniPromptOptimizer("distilgpt2")
+    with patch.object(omni.advanced, "optimize_prompt", return_value="p1"), \
+         patch.object(omni.bandit, "optimize_prompt", return_value="p2"), \
+         patch.object(omni.annealer, "optimize_prompt", return_value="p3"), \
+         patch.object(omni.rl, "optimize_prompt", return_value="p4"), \
+         patch.object(omni.bayes, "optimize_prompt", return_value="p5"), \
+         patch.object(omni.evolver, "evolve_prompt", return_value="p6"), \
+         patch.object(omni.tuner, "tune"), \
+         patch.object(omni.tuner, "get_prompt_tokens", return_value=["tok"]), \
+         patch.object(PromptOptimizer, "score_prompt", side_effect=[6, 5, 4, 3, 2, 1, 0.5, 0]):
+        best = omni.optimize_prompt("base")
+    assert best == "tok base"


### PR DESCRIPTION
## Summary
- implement `OmniPromptOptimizer` that chains every optimizer
- export new optimizer in package
- document the new optimizer in README
- add unit test for OmniPromptOptimizer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68801d5f76e883319651a0f0a65bb8ac