### PR TITLE
Add self‑learning bot workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For the most comprehensive demonstration, which additionally clusters embeddings
 python3 ultimate_workflow.py
 ```
 
+For a minimal example that removes reliance on static datasets and
+continuously learns from new data, run `self_learning_bot.py`:
+```bash
+python3 self_learning_bot.py
+```
+
 To start the collaboration server used for peer collaboration, run the following in a separate process:
 ```bash
 python3 peer_collab/collaboration_server.py

--- a/self_learning_bot.py
+++ b/self_learning_bot.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Self-learning workflow unifying real-time data absorption with prompt optimization."""
+
+import argparse
+import threading
+import time
+from queue import Queue
+from typing import Optional
+
+
+from main import load_config, initialize_system
+from analysis.omni_prompt_optimizer import OmniPromptOptimizer
+from interface.ws_server import run_ws_server
+
+
+def process_latest(absorber, optimizer: OmniPromptOptimizer) -> Optional[str]:
+    """Optimize a prompt for the most recent text datapoint."""
+    if not getattr(absorber, "data_buffer", None):
+        return None
+    data_point = absorber.data_buffer[-1]
+    if getattr(data_point, "modality", None) != "text":
+        return None
+    best = optimizer.optimize_prompt(data_point.data)
+    return best
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the self-learning bot")
+    parser.add_argument("--config", default="config.yaml", help="Path to YAML config")
+    parser.add_argument(
+        "--watch-interval", type=float, default=5.0, help="Seconds between file scans"
+    )
+    args = parser.parse_args(argv)
+
+    cfg = load_config(args.config)
+    metrics_q: Queue = Queue()
+    ws_thread = threading.Thread(target=run_ws_server, args=(metrics_q,), daemon=True)
+    ws_thread.start()
+
+    absorber, watcher, _ = initialize_system(cfg, metrics_q, args.watch_interval)
+    optimizer = OmniPromptOptimizer(cfg.get("model", {}).get("name", "distilgpt2"))
+
+    absorber.start_absorption()
+    watcher.start()
+
+    try:
+        while True:
+            best = process_latest(absorber, optimizer)
+            if best:
+                print("Optimized prompt:", best)
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        watcher.stop()
+        absorber.stop_absorption()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_self_learning_bot.py
+++ b/tests/test_self_learning_bot.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from self_learning_bot import process_latest
+
+
+def test_process_latest_text():
+    dp = SimpleNamespace(modality="text", data="hello")
+    absorber = SimpleNamespace(data_buffer=[dp])
+    optimizer = MagicMock(optimize_prompt=MagicMock(return_value="best"))
+
+    best = process_latest(absorber, optimizer)
+
+    assert best == "best"
+    optimizer.optimize_prompt.assert_called_with("hello")


### PR DESCRIPTION
## Summary
- implement `self_learning_bot.py` to fuse real-time data absorption with prompt optimization
- document the new script in README
- test `process_latest` helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6880214bd1a48331aea76c41c0685858