### PR TITLE
Final release prep

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,25 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Build package
+      run: |
+        python -m pip install --upgrade pip build
+        python -m build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        skip-existing: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NeuroFluxLIVE
 
-**NeuroFluxLIVE** provides a unified pipeline for building self-learning agents without relying on static datasets. Real-time data ingestion is fused with several prompt optimisation strategies so models can adapt as new information arrives. Version 1.0.0 marks our first production-ready release on PyPI.
+**NeuroFluxLIVE** provides a unified pipeline for building self-learning agents without relying on static datasets. Real-time data ingestion is fused with several prompt optimisation strategies so models can adapt as new information arrives. Version 1.0.1 marks our first production-ready release on PyPI.
 
 ## Key Features
 - **Datasetless learning** – `RealTimeDataAbsorber` streams text, audio and images directly into optimisation routines.

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ SelfResearch – package wrapper & legacy-import shim.
 • Aliases old absolute imports like  `import analysis.foo`
   to the new fully-qualified path `SelfResearch.analysis.foo`.
 """
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 from pathlib import Path
 import importlib, pkgutil, sys as _sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SelfResearch"
-version = "1.0.0"
+version = "1.0.1"
 description = "Unified pipeline for self-learning agents with real-time data ingestion"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump version to `1.0.1`
- install dev requirements in CI
- add PyPI release workflow

## Testing
- `pytest tests/test_training_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880489e8c5c833184c5ba7511fab8fd