### PR TITLE
Finalize packaging for v1.0.2

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NeuroFluxLIVE
 
-**NeuroFluxLIVE** provides a unified pipeline for building self-learning agents without relying on static datasets. Real-time data ingestion is fused with several prompt optimisation strategies so models can adapt as new information arrives. Version 1.0.1 marks our first production-ready release on PyPI.
+**NeuroFluxLIVE** provides a unified pipeline for building self-learning agents without relying on static datasets. Real-time data ingestion is fused with several prompt optimisation strategies so models can adapt as new information arrives. Version 1.0.2 marks our first production-ready release on PyPI.
 
 ## Key Features
 - **Datasetless learning** – `RealTimeDataAbsorber` streams text, audio and images directly into optimisation routines.

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ SelfResearch – package wrapper & legacy-import shim.
 • Aliases old absolute imports like  `import analysis.foo`
   to the new fully-qualified path `SelfResearch.analysis.foo`.
 """
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 from pathlib import Path
 import importlib, pkgutil, sys as _sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "SelfResearch"
-version = "1.0.1"
+version = "1.0.2"
 description = "Unified pipeline for self-learning agents with real-time data ingestion"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -41,5 +41,7 @@ dependencies = [
 # Tell setuptools that the *current folder* (“.”) IS the package.
 # ------------------------------------------------------------------
 [tool.setuptools]
-packages = ["SelfResearch"]
 package-dir = { "SelfResearch" = "" }   #  ← key fix
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["SelfResearch*"]


### PR DESCRIPTION
## Summary
- bump version to 1.0.2
- allow setuptools to find all subpackages
- update README for the release
- test on Python 3.12 in the workflow

## Testing
- `pytest -q` *(fails: 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68804c6159a0833182c9186ce792f68a