### PR TITLE
Add automatic dataset collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Key Features
 - **Datasetless learning** – `RealTimeDataAbsorber` streams text, audio and images directly into optimisation routines.
+- **Automated dataset retrieval** – `AutoDataCollector` searches the Hugging Face Hub and downloads datasets without manual steps.
 - **Unified prompt optimisation** – `UnifiedPromptOptimizer` combines evolutionary, bandit, annealing and RL strategies under one interface.
 - **Research utilities** – tools for simulation, source evaluation, ethics management and collaboration are included.
 - **Modular design** – packages under `analysis`, `train`, `models`, `digital_literacy` and more can be used independently or together.

--- a/data/auto_data_collector.py
+++ b/data/auto_data_collector.py
@@ -1,0 +1,75 @@
+"""Utilities for automatically fetching datasets from the Hugging Face Hub."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+
+# Importing `datasets` lazily so the module can be imported without the
+# dependency installed. Functions will raise an informative error if the
+# library is missing.
+from importlib import import_module
+
+
+def _datasets():
+    try:
+        return import_module("datasets")
+    except ImportError as exc:
+        raise ImportError(
+            "The 'datasets' library is required for AutoDataCollector."
+        ) from exc
+
+
+logger = logging.getLogger(__name__)
+
+
+def search_hf_datasets(query: str, limit: int = 10) -> List[str]:
+    """Return dataset names containing the query string."""
+    query = query.lower()
+    ds_mod = _datasets()
+    names = [name for name in ds_mod.list_datasets() if query in name.lower()]
+    return names[:limit]
+
+
+def download_dataset(name: str, split: str, output_dir: str | Path) -> Path:
+    """Download a split from the hub and save it as JSONL.
+
+    Args:
+        name: Dataset identifier on Hugging Face.
+        split: Which split to download.
+        output_dir: Directory to save the JSONL file.
+
+    Returns:
+        Path to the saved file.
+    """
+    ds_mod = _datasets()
+    ds: Dataset = ds_mod.load_dataset(name, split=split)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{name.replace('/', '_')}_{split}.jsonl"
+    ds.to_json(str(path))
+    return path
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Download datasets from HF Hub")
+    parser.add_argument("--query", required=True, help="Search term")
+    parser.add_argument("--max_datasets", type=int, default=3)
+    parser.add_argument("--split", default="train")
+    parser.add_argument("--output_dir", default="datasets")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    names = search_hf_datasets(args.query, args.max_datasets)
+    logger.info("Found %d dataset(s) for '%s'", len(names), args.query)
+    for name in names:
+        logger.info("Downloading %s...", name)
+        path = download_dataset(name, args.split, args.output_dir)
+        logger.info("Saved to %s", path)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/automatic_data_retrieval.md
+++ b/docs/automatic_data_retrieval.md
@@ -1,0 +1,35 @@
+# Automatic Data Retrieval
+
+The `AutoDataCollector` utility automates the process of searching and
+retrieving high quality datasets from the Hugging Face Hub. It is designed to
+work with the existing dataset loaders so that newly fetched data can be quickly
+used for training and analysis.
+
+## Features
+- **Query based search** – datasets are discovered with a search term using the
+  `datasets` library.
+- **Batch downloading** – multiple datasets can be fetched at once and saved in
+  JSONL format.
+- **Integration ready** – saved files can be loaded with
+  `data.dataset_loader.load_local_json_dataset` or streamed directly into
+  `RealTimeDataAbsorber`.
+
+## Usage
+```bash
+python -m data.auto_data_collector --query "news" --max_datasets 3 --output_dir ./datasets
+```
+This will search for datasets containing "news" in their name, download up to
+three of them and store each split as a JSONL file in `./datasets`.
+
+## Data Quality Tips
+1. **Inspect metadata** – review the dataset card on Hugging Face for licensing
+   and source information.
+2. **Deduplicate** – use `drop_duplicates` in `dataset_loader.load_and_tokenize`
+   to remove repeated samples.
+3. **Track provenance** – keep a log of dataset names and versions for
+   reproducibility.
+4. **Validate content** – run `digital_literacy/source_evaluator.py` on samples
+   to check for credibility and bias.
+
+For large scale ingestion, combine the collector with the `RealTimeDataAbsorber`
+so that models continuously adapt to new, validated data sources.

--- a/tests/test_auto_data_collector.py
+++ b/tests/test_auto_data_collector.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from data.auto_data_collector import search_hf_datasets, download_dataset
+
+
+class DummyDataset:
+    def __init__(self, items):
+        self.items = items
+
+    def to_json(self, path: str) -> None:
+        from json import dumps
+
+        with open(path, "w") as f:
+            for item in self.items:
+                f.write(dumps(item) + "\n")
+
+
+def test_search_hf_datasets():
+    dummy_mod = SimpleNamespace(list_datasets=lambda: ['ag_news', 'wikitext', 'openwebtext'])
+    with patch('data.auto_data_collector._datasets', return_value=dummy_mod):
+        result = search_hf_datasets('wiki', limit=2)
+    assert result == ['wikitext']
+
+
+def test_download_dataset(tmp_path: Path):
+    dummy_ds = DummyDataset([{'text': 'hello'}])
+    dummy_mod = SimpleNamespace(load_dataset=lambda name, split=None: dummy_ds)
+    with patch('data.auto_data_collector._datasets', return_value=dummy_mod):
+        path = download_dataset('dummy', 'train', tmp_path)
+    assert path.exists()
+    assert path.read_text().strip() == '{"text": "hello"}'


### PR DESCRIPTION
## Summary
- implement `AutoDataCollector` to fetch datasets from the HF Hub
- document automatic retrieval and add data quality tips
- list new tool in README
- include tests for the collector

## Testing
- `pytest -q tests/test_auto_data_collector.py`

------
https://chatgpt.com/codex/tasks/task_e_688183ba0ca48331b37b09d0ae146cb8