### PR TITLE
Add persistent compressed memory

### DIFF
--- a/RealTimeDataAbsorber.py
+++ b/RealTimeDataAbsorber.py
@@ -1057,6 +1057,12 @@ class RealTimeDataAbsorber:
                     (k, float(v), ts.isoformat()),
                 )
             conn.commit()
+        if self.corr_mem is not None:
+            self.performance_metrics["memory_items"] = len(self.corr_mem.labels)
+            try:
+                self.corr_mem.save()
+            except Exception as e:
+                logging.error(f"Memory save error: {e}")
 
 # ─────────────────────────────────────────────────────────────────────────────── #
 # Example usage (remove / comment-out when importing as a library)

--- a/docs/persistent_memory.md
+++ b/docs/persistent_memory.md
@@ -1,0 +1,19 @@
+# Persistent Correlation Memory
+
+`CorrelationRAGMemory` can optionally compress stored embeddings with a `VAECompressor`.
+Compressed representations and the FAISS index are saved to disk so that memories
+persist across sessions. Use `save()` and `load()` to manage state manually or
+allow `RealTimeDataAbsorber.log_performance_metrics()` to trigger automatic
+saves.
+
+Example:
+```python
+from correlation_rag_module import CorrelationRAGMemory
+from models.vae_compressor import VAECompressor
+
+compressor = VAECompressor(latent_dim=16)
+memory = CorrelationRAGMemory(emb_dim=384, save_path="synergy.mem",
+                              compressor=compressor)
+```
+When run again with the same `save_path`, the memory is reloaded
+automatically.

--- a/synergy_workflow.py
+++ b/synergy_workflow.py
@@ -9,6 +9,8 @@ from analysis.hyper_prompt_optimizer import HyperPromptOptimizer
 
 if TYPE_CHECKING:
     from RealTimeDataAbsorber import RealTimeDataAbsorber
+    from correlation_rag_module import CorrelationRAGMemory
+    from models.vae_compressor import VAECompressor
 
 
 def main() -> None:
@@ -17,7 +19,12 @@ def main() -> None:
 
     from RealTimeDataAbsorber import RealTimeDataAbsorber
 
+    compressor = VAECompressor(latent_dim=16)
+    rag = CorrelationRAGMemory(emb_dim=384, save_path="synergy.mem", compressor=compressor)
+
     absorber = RealTimeDataAbsorber(model_config={}, settings={"db_path": ":memory:"})
+    if hasattr(absorber, "attach_rag"):
+        absorber.attach_rag(rag)
     absorber.absorb_data("Initial data point", "text")
 
     optimizer = HyperPromptOptimizer("distilgpt2", absorber=absorber, device=device)
@@ -27,6 +34,10 @@ def main() -> None:
         print(f"Refined prompt: {prompt}")
         text = optimizer.generate_variations(prompt, n_variations=1)[0]
         print(f"Generated text: {text[:80]}")
+
+    if hasattr(absorber, "log_performance_metrics"):
+        absorber.log_performance_metrics()
+    rag.save()
 
 
 if __name__ == "__main__":

--- a/tests/test_synergy_workflow.py
+++ b/tests/test_synergy_workflow.py
@@ -28,4 +28,12 @@ def test_main_runs(monkeypatch):
     dummy_mod.RealTimeDataAbsorber = DummyAbsorber
     monkeypatch.setitem(sys.modules, "RealTimeDataAbsorber", dummy_mod)
 
+    fake_rag = types.ModuleType("correlation_rag_module")
+    fake_rag.CorrelationRAGMemory = lambda *a, **k: SimpleNamespace(save=lambda: None)
+    monkeypatch.setitem(sys.modules, "correlation_rag_module", fake_rag)
+
+    fake_comp = types.ModuleType("models.vae_compressor")
+    fake_comp.VAECompressor = lambda *a, **k: object()
+    monkeypatch.setitem(sys.modules, "models.vae_compressor", fake_comp)
+
     synergy_workflow.main()


### PR DESCRIPTION
## Summary
- let `CorrelationRAGMemory` store optional VAE-compressed vectors and expose `load`
- save memory automatically from `RealTimeDataAbsorber.log_performance_metrics`
- demonstrate persistence in `synergy_workflow`
- document persistent memory usage
- update synergy workflow tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688192c53f2c8331a292ff5f6e64e66b