### PR TITLE
Add persistent RAG memory docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
    ```
 
 ## Usage
-Run the core datasetless demo:
+Run the core datasetless demo (which demonstrates persistent memory across
+sessions):
 ```bash
 python synergy_workflow.py
 ```
@@ -53,6 +54,11 @@ compressor = VAECompressor(latent_dim=32)
 absorber = RealTimeDataAbsorber(model_config={}, compressor=compressor)
 ```
 Embeddings will be compressed before being cached and transparently decompressed when accessed.
+
+When `CorrelationRAGMemory` is constructed with a `VAECompressor` and a
+`save_path`, compressed memories are persisted on disk. Calling
+`RealTimeDataAbsorber.log_performance_metrics()` will periodically save this
+state so that subsequent runs can reload it automatically.
 
 ## Metrics
 A quick benchmark with `distilgpt2` on a tiny AG News subset results in:

--- a/correlation_rag_module.py
+++ b/correlation_rag_module.py
@@ -15,11 +15,17 @@ def _l2norm(x: np.ndarray) -> np.ndarray:
 
 # ----------------------------------------------------------------------
 class CorrelationRAGMemory:
-    """
-    • add(emb, label, meta)           → store embedding & metadata
-    • retrieve(query, k)              → top-k (emb, label, meta, score)
-    • classify(query)                 → returns logits + context
-    • update_head(batch_emb, batch_y) → online ridge-regression update
+    """Lightweight retrieval-augmented memory.
+
+    When a ``VAECompressor`` is provided, added embeddings are compressed and
+    saved alongside the FAISS index. ``save()`` writes both structures to disk
+    and ``load()`` restores them so that memories persist across sessions.
+
+    Public API:
+        • add(emb, label, meta)           → store embedding & metadata
+        • retrieve(query, k)              → top-k (emb, label, meta, score)
+        • classify(query)                 → returns logits + context
+        • update_head(batch_emb, batch_y) → online ridge‑regression update
     """
 
     def __init__(self,

--- a/docs/persistent_memory.md
+++ b/docs/persistent_memory.md
@@ -1,10 +1,11 @@
 # Persistent Correlation Memory
 
-`CorrelationRAGMemory` can optionally compress stored embeddings with a `VAECompressor`.
-Compressed representations and the FAISS index are saved to disk so that memories
-persist across sessions. Use `save()` and `load()` to manage state manually or
-allow `RealTimeDataAbsorber.log_performance_metrics()` to trigger automatic
-saves.
+`CorrelationRAGMemory` can compress stored embeddings with a `VAECompressor` and
+persist them to disk. Both the compressed representations and FAISS index are
+stored so that memories survive application restarts. Call `save()` to write the
+current state or rely on `RealTimeDataAbsorber.log_performance_metrics()` which
+invokes `save()` automatically once per hour. Use `load()` to restore a memory
+file.
 
 Example:
 ```python
@@ -15,5 +16,5 @@ compressor = VAECompressor(latent_dim=16)
 memory = CorrelationRAGMemory(emb_dim=384, save_path="synergy.mem",
                               compressor=compressor)
 ```
-When run again with the same `save_path`, the memory is reloaded
-automatically.
+Running again with the same `save_path` will automatically reload the previous
+memory, enabling continuous learning across sessions.

--- a/synergy_workflow.py
+++ b/synergy_workflow.py
@@ -18,9 +18,13 @@ def main() -> None:
     print(f"Using device: {device}")
 
     from RealTimeDataAbsorber import RealTimeDataAbsorber
+    from models.vae_compressor import VAECompressor
+    from correlation_rag_module import CorrelationRAGMemory
 
     compressor = VAECompressor(latent_dim=16)
     rag = CorrelationRAGMemory(emb_dim=384, save_path="synergy.mem", compressor=compressor)
+    if hasattr(rag, "labels"):
+        print(f"Loaded {len(rag.labels)} memory items")
 
     absorber = RealTimeDataAbsorber(model_config={}, settings={"db_path": ":memory:"})
     if hasattr(absorber, "attach_rag"):
@@ -37,7 +41,6 @@ def main() -> None:
 
     if hasattr(absorber, "log_performance_metrics"):
         absorber.log_performance_metrics()
-    rag.save()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `CorrelationRAGMemory` docstring with persistence details
- note long-term memory in README and docs
- update `synergy_workflow.py` to show loading persistent memory
- rely on `log_performance_metrics` to save memory

## Testing
- `pytest tests/test_synergy_workflow.py::test_main_runs -q`

------
https://chatgpt.com/codex/tasks/task_e_6881952051e4833181e6359e8fc00066