### PR TITLE
Specify dtype when loading multimodal tensors

### DIFF
--- a/multimodal_dataset_manager.py
+++ b/multimodal_dataset_manager.py
@@ -264,12 +264,12 @@ class MultimodalDataset(Dataset):
         elif rec.modality == "image":
             with Image.open(path) as img:
                 arr = np.array(img.convert("RGB"))
-            tensor = torch.tensor(arr).permute(2, 0, 1)
+            tensor = torch.tensor(arr, dtype=torch.uint8).permute(2, 0, 1)
         elif rec.modality == "audio":
             audio, _ = sf.read(path.as_posix())
             if audio.ndim > 1:
                 audio = np.mean(audio, axis=1)
-            tensor = torch.tensor(audio)
+            tensor = torch.tensor(audio, dtype=torch.float32)
         elif rec.modality == "sensor":
             obj = json.loads(path.read_text())
             values = list(obj.values()) if isinstance(obj, dict) else obj

--- a/tests/test_multimodal_dataset.py
+++ b/tests/test_multimodal_dataset.py
@@ -57,7 +57,20 @@ def test_multimodal_dataset_getitem(tmp_path):
     tensor, rec = ds[0]
     assert isinstance(tensor, torch.Tensor)
     assert rec.modality == "text"
+    assert tensor.dtype == torch.uint8
     assert cache.get("t") is not None
+
+    tensor, rec = ds[1]
+    assert rec.modality == "image"
+    assert tensor.dtype == torch.uint8
+
+    tensor, rec = ds[2]
+    assert rec.modality == "audio"
+    assert tensor.dtype == torch.float32
+
+    tensor, rec = ds[3]
+    assert rec.modality == "sensor"
+    assert tensor.dtype == torch.float32
 
     loader = create_balanced_dataloader(ds, batch_size=2, shuffle=False)
     ids = []


### PR DESCRIPTION
## Summary
- enforce explicit dtype for all `_load_tensor` branches
- extend multimodal dataset test to check tensor dtypes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db8625ce083318c4c94a703bca99d