### PR TITLE
Pin numpy dependency to >=1.23,<2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 ```
-The requirements files pin `numpy<2` to maintain compatibility with PyTorch.
+The requirements files pin `numpy>=1.23,<2.0` to maintain compatibility with PyTorch.
 Development extras and tests can be installed with:
 ```bash
 pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 torch==2.2.0
-numpy<2
+numpy>=1.23,<2.0
 datasets
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch==2.2.0
-numpy<2
+numpy>=1.23,<2.0
 transformers
 scikit-learn
 flask


### PR DESCRIPTION
## Summary
- pin numpy to `>=1.23,<2.0` in runtime and development requirements
- document the numpy pin in installation instructions

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest` *(interrupted after 46 tests; remaining tests run individually and passed)*
- `pytest tests/test_ultimate_workflow.py`
- `pytest tests/test_unified_prompt_optimizer.py tests/test_vae_compressor.py tests/test_visual_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_688dd1a60f24833183ca2e99d375d492