### PR TITLE
Add GPT-2 benchmark utilities and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,20 @@ When `CorrelationRAGMemory` is constructed with a `VAECompressor` and a
 `RealTimeDataAbsorber.log_performance_metrics()` will periodically save this
 state so that subsequent runs can reload it automatically.
 
-## Metrics
-A quick benchmark with `distilgpt2` on a tiny AG News subset results in:
-```
-Perplexity: 6785.07
-```
+## GPT-2 Benchmark 🚀
+Using the `eval/gpt2_benchmark.py` helper we fine-tuned GPT-2 on a 100-sample slice of the AG News dataset and measured perplexity on a held-out subset:
+
+| Model | Perplexity (AG News test[:50]) |
+|-------|-------------------------------|
+| GPT-2 baseline | 67.96 |
+| GPT-2 fine-tuned ⚙️ | 51.94 |
+
+Prompt `Breaking news:` showcased the improvement:
+
+> **Baseline:** Breaking news: The FBI has released a list of the people who have been arrested in connection with the shooting death of a black man in Ferguson, Missouri.
+
+> **Fine-tuned:** Breaking news: The U.S. Supreme Court has ruled that the government can't force a company to pay for a product that it says is defective. The case is the latest in a series of cases that have been brought by companies that have sued
+
 `RealTimeDataAbsorber` exposes live metrics over WebSockets during extended sessions.
 
 ## Project Layout

--- a/eval/gpt2_benchmark.py
+++ b/eval/gpt2_benchmark.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import argparse
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from language_model_evaluator import evaluate_perplexity
+
+
+def run_benchmark(
+    base_model: str,
+    tuned_model: str,
+    dataset: str,
+    *,
+    dataset_config: str | None = None,
+    split: str = "test[:50]",
+    text_column: str = "text",
+    max_length: int | None = 128,
+    prompt: str = "Hello",
+) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    base_ppl = evaluate_perplexity(
+        base_model,
+        dataset,
+        dataset_config=dataset_config,
+        split=split,
+        text_column=text_column,
+        max_length=max_length,
+        device=str(device),
+    )
+    tuned_ppl = evaluate_perplexity(
+        tuned_model,
+        dataset,
+        dataset_config=dataset_config,
+        split=split,
+        text_column=text_column,
+        max_length=max_length,
+        device=str(device),
+    )
+    tokenizer = AutoTokenizer.from_pretrained(base_model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    base = AutoModelForCausalLM.from_pretrained(base_model).to(device)
+    tuned = AutoModelForCausalLM.from_pretrained(tuned_model).to(device)
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to(device)
+    base_gen = tokenizer.decode(base.generate(input_ids, max_length=50)[0], skip_special_tokens=True)
+    tuned_gen = tokenizer.decode(tuned.generate(input_ids, max_length=50)[0], skip_special_tokens=True)
+    print(f"Baseline PPL: {base_ppl:.2f}")
+    print(f"Fine-tuned PPL: {tuned_ppl:.2f}")
+    print("\nBaseline generation:\n" + base_gen)
+    print("\nFine-tuned generation:\n" + tuned_gen)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GPT-2 benchmarking helper")
+    parser.add_argument("base_model")
+    parser.add_argument("tuned_model")
+    parser.add_argument("dataset")
+    parser.add_argument("--dataset-config")
+    parser.add_argument("--split", default="test[:50]")
+    parser.add_argument("--text-column", default="text")
+    parser.add_argument("--max-length", type=int, default=128)
+    parser.add_argument("--prompt", default="Hello world")
+    args = parser.parse_args()
+    run_benchmark(
+        args.base_model,
+        args.tuned_model,
+        args.dataset,
+        dataset_config=args.dataset_config,
+        split=args.split,
+        text_column=args.text_column,
+        max_length=args.max_length,
+        prompt=args.prompt,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/language_model_evaluator.py
+++ b/eval/language_model_evaluator.py
@@ -14,30 +14,52 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 def evaluate_perplexity(
     model_name: str,
     dataset_name: str,
+    dataset_config: Optional[str] = None,
     split: str = "test",
     text_column: str = "text",
     device: Optional[str] = None,
+    max_length: Optional[int] = None,
 ) -> float:
     """Compute perplexity of a model on a given dataset split."""
+
     device_t = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
     model = AutoModelForCausalLM.from_pretrained(model_name).to(device_t)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
-    dataset = load_dataset(dataset_name, split=split)
+    dataset = load_dataset(dataset_name, dataset_config, split=split)
+    dataset = dataset.filter(lambda e: e[text_column] and not e[text_column].isspace())
 
     def tokenize(batch):
-        return tokenizer(batch[text_column], truncation=True, padding="max_length")
+        enc = tokenizer(
+            batch[text_column],
+            truncation=True,
+            padding=True,
+            max_length=max_length,
+        )
+        labels = [ids.copy() for ids in enc["input_ids"]]
+        for label, mask in zip(labels, enc["attention_mask"]):
+            for i, m in enumerate(mask):
+                if m == 0:
+                    label[i] = -100
+        enc["labels"] = labels
+        return enc
 
     dataset = dataset.map(tokenize, batched=True)
-    dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
+    dataset.set_format(type="torch", columns=["input_ids", "attention_mask", "labels"])
 
     nlls = []
     for sample in dataset:
         input_ids = sample["input_ids"].unsqueeze(0).to(device_t)
+        attention_mask = sample["attention_mask"].unsqueeze(0).to(device_t)
+        labels = sample["labels"].unsqueeze(0).to(device_t)
         with torch.no_grad():
-            output = model(input_ids=input_ids, labels=input_ids)
+            output = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                labels=labels,
+            )
         nlls.append(output.loss.item())
     avg_nll = sum(nlls) / len(nlls)
     return float(math.exp(avg_nll))
@@ -47,14 +69,18 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Evaluate model perplexity")
     parser.add_argument("model_name", help="Model identifier")
     parser.add_argument("dataset", help="Dataset name")
+    parser.add_argument("--dataset-config", help="Optional dataset config")
     parser.add_argument("--split", default="test", help="Dataset split")
     parser.add_argument("--text-column", default="text", help="Text column name")
+    parser.add_argument("--max-length", type=int, help="Truncate sequences to this length")
     args = parser.parse_args()
     ppl = evaluate_perplexity(
         model_name=args.model_name,
         dataset_name=args.dataset,
+        dataset_config=args.dataset_config,
         split=args.split,
         text_column=args.text_column,
+        max_length=args.max_length,
     )
     print(f"Perplexity: {ppl:.2f}")
 

--- a/train/trainer.py
+++ b/train/trainer.py
@@ -65,6 +65,7 @@ class TrainingConfig:
 
     # data / text
     text_column: str = "text"
+    max_length: Optional[int] = None
 
     # training
     output_dir: str = "./model_output"
@@ -111,6 +112,7 @@ def train_model(
         train_split=cfg.train_split,
         eval_split=cfg.eval_split,
         text_column=cfg.text_column,
+        max_length=cfg.max_length,
     )
 
     # 🧠 Model & Tokenizer ---------------------------------------------
@@ -121,6 +123,8 @@ def train_model(
     model.to(device)
 
     tokenizer = AutoTokenizer.from_pretrained(cfg.model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
 
     # ⚙️ TrainingArguments ---------------------------------------------
     training_args = TrainingArguments(
@@ -196,6 +200,7 @@ def main() -> None:
     parser.add_argument("--warmup-steps", type=int, default=0)
     parser.add_argument("--lr-scheduler", default="linear")
     parser.add_argument("--max-grad-norm", type=float, default=1.0)
+    parser.add_argument("--max-length", type=int, help="Truncate sequences to this length")
     parser.add_argument("--fp16", action="store_true")
     parser.add_argument("--bf16", action="store_true")
     parser.add_argument("--gradient-ckpt", action="store_true")
@@ -218,6 +223,7 @@ def main() -> None:
         warmup_steps=args.warmup_steps,
         lr_scheduler_type=args.lr_scheduler,
         max_grad_norm=args.max_grad_norm,
+        max_length=args.max_length,
         fp16=args.fp16,
         bf16=args.bf16,
         gradient_ckpt=args.gradient_ckpt,


### PR DESCRIPTION
## Summary
- improve language model evaluator to handle padding and dataset configs
- allow trainer to control sequence length and pad tokens
- add standalone GPT-2 benchmark script
- document AG News perplexity improvements and sample generations

## Testing
- `python eval/gpt2_benchmark.py gpt2 models/gpt2-ag-news-mini ag_news --split test[:50] --text-column text --max-length 128 --prompt "Breaking news:" | tail -n 20`
- `pytest` *(interrupted after 26 tests; 26 passed, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688ddd95632c83318ccd3d1f384bedfd