### PR TITLE
Add GPT-2 Gym trainer with real-time streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ and t-SNE, executes short training loops, and calls the collaboration server,
 it benefits from a CUDA‑enabled GPU and at least **8 GB** of system RAM. On a
 CPU-only machine the demo may take several minutes to complete.
 
+### Autonomous Gym Trainer
+An optional reinforcement-learning demo can be launched with:
+
+```bash
+python ultimate_workflow.py --run-gym
+```
+
+This invokes `simulation_lab/gym_autonomous_trainer.py`, which wraps a classic
+Gym environment using GPT‑2 for policy and value prediction. Runtime
+requirements are `gym` and `torch`. During training the module reports episode
+returns and streams generated responses through `RealTimeDataAbsorber`.
+
+Expected metrics:
+
+- **Average return** per episode.
+- **Sample responses** generated alongside environment interaction.
+
 ### Embedding Compression
 `VAECompressor` can be attached to `RealTimeDataAbsorber` to reduce the size of stored embeddings. Pass an instance when constructing the absorber. The compressor trains a small variational autoencoder so embeddings are encoded to a latent vector and reconstructed only when accessed:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ torchvision
 lmdb
 msgpack
 websockets
+gym

--- a/simulation_lab/gym_autonomous_trainer.py
+++ b/simulation_lab/gym_autonomous_trainer.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+"""Minimal autonomous trainer using a Gym environment and GPT-2.
+
+This module demonstrates how a transformer model can drive reinforcement
+learning without relying on a fixed dataset.  At each step the model both
+selects an action for the environment **and** answers a user prompt.  The
+response alongside the reward signal is streamed to ``RealTimeDataAbsorber``
+so that metrics can be consumed by other components in real time.
+"""
+
+from dataclasses import dataclass
+from queue import Queue
+from typing import List, Tuple
+
+import gym
+import logging
+import torch
+from torch import nn
+from torch.distributions import Categorical
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class TrainerConfig:
+    """Configuration for :func:`run_gym_autonomous_trainer`"""
+
+    env_name: str = "CartPole-v1"
+    episodes: int = 3
+    gamma: float = 0.99
+    model_name: str = "gpt2"
+    prompt: str = "Provide a motivational message for the next move."
+
+
+def run_gym_autonomous_trainer(cfg: TrainerConfig | None = None) -> Tuple[List[float], List[str]]:
+    """Train a small policy/value head on top of GPT-2 in a Gym environment.
+
+    Parameters
+    ----------
+    cfg:
+        Optional :class:`TrainerConfig`.  Uses sensible defaults if omitted.
+
+    Returns
+    -------
+    Tuple[List[float], List[str]]
+        Episode rewards and a sample of textual responses generated during
+        interaction.
+    """
+
+    cfg = cfg or TrainerConfig()
+    if not log.handlers:
+        logging.basicConfig(level=logging.INFO)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    env = gym.make(cfg.env_name)
+    tokenizer = AutoTokenizer.from_pretrained(cfg.model_name)
+    model = AutoModelForCausalLM.from_pretrained(cfg.model_name).to(device)
+
+    policy_head = nn.Linear(model.config.n_embd, env.action_space.n).to(device)
+    value_head = nn.Linear(model.config.n_embd, 1).to(device)
+    optimiser = torch.optim.Adam(
+        list(policy_head.parameters()) + list(value_head.parameters()), lr=1e-3
+    )
+
+    metrics_queue: Queue = Queue()
+    from RealTimeDataAbsorber import RealTimeDataAbsorber  # Lazy import
+
+    absorber = RealTimeDataAbsorber(model_config={}, metrics_queue=metrics_queue)
+
+    episode_returns: List[float] = []
+    responses: List[str] = []
+
+    for ep in range(cfg.episodes):
+        obs, _ = env.reset()
+        done = False
+        transitions = []
+        step = 0
+        ep_return = 0.0
+
+        while not done:
+            obs_text = " ".join(f"{o:.2f}" for o in obs)
+            tokens = tokenizer(obs_text, return_tensors="pt").to(device)
+            with torch.no_grad():
+                hidden = model.transformer(**tokens).last_hidden_state[:, -1, :]
+            logits = policy_head(hidden)
+            value = value_head(hidden).squeeze(-1)
+            dist = Categorical(logits=logits)
+            action = dist.sample()
+            log_prob = dist.log_prob(action)
+
+            next_obs, reward, terminated, truncated, _ = env.step(action.item())
+            done = terminated or truncated
+            ep_return += float(reward)
+
+            prompt_ids = tokenizer(cfg.prompt, return_tensors="pt").to(device)
+            response_ids = model.generate(
+                **prompt_ids,
+                max_length=prompt_ids["input_ids"].shape[1] + 20,
+                do_sample=True,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+            response_text = tokenizer.decode(response_ids[0], skip_special_tokens=True)
+            responses.append(response_text)
+
+            log.info(
+                "Episode %d Step %d | Reward: %.2f | Response: %s",
+                ep,
+                step,
+                reward,
+                response_text,
+            )
+
+            absorber.performance_metrics.update(
+                {"latest_reward": float(reward), "episode": ep, "step": step}
+            )
+            absorber.absorb_data(
+                response_text, "text", source="gym_autonomous_trainer", priority=1
+            )
+            absorber._emit_metrics()
+
+            transitions.append((log_prob, value, reward))
+            obs = next_obs
+            step += 1
+
+        episode_returns.append(ep_return)
+
+        returns = []
+        G = 0.0
+        for _, _, r in reversed(transitions):
+            G = r + cfg.gamma * G
+            returns.insert(0, G)
+        returns_t = torch.tensor(returns, device=device)
+        log_probs = torch.stack([t[0] for t in transitions])
+        values = torch.stack([t[1] for t in transitions])
+        advantage = returns_t - values.detach()
+
+        policy_loss = -(log_probs * advantage).mean()
+        value_loss = (returns_t - values).pow(2).mean()
+        loss = policy_loss + value_loss
+
+        optimiser.zero_grad()
+        loss.backward()
+        optimiser.step()
+
+    env.close()
+    return episode_returns, responses[:5]
+
+
+__all__ = ["TrainerConfig", "run_gym_autonomous_trainer"]

--- a/ultimate_workflow.py
+++ b/ultimate_workflow.py
@@ -12,6 +12,11 @@ from typing import Any
 import torch
 import requests
 
+from simulation_lab.gym_autonomous_trainer import (
+    TrainerConfig,
+    run_gym_autonomous_trainer,
+)
+
 from research_workflow.topic_selector import TopicSelector
 from digital_literacy.source_evaluator import SourceEvaluator
 from simulation_lab.experiment_simulator import ExperimentSimulator
@@ -32,7 +37,7 @@ from analysis.prompt_bandit_optimizer import PromptBanditOptimizer
 from analysis.prompt_bayes_optimizer import PromptBayesOptimizer
 
 
-def main() -> None:
+def main(run_gym: bool = False) -> None:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print(f"Using device: {device}")
 
@@ -77,6 +82,11 @@ def main() -> None:
     ppl = evaluate_perplexity("distilgpt2", "ag_news", split="test[:10]")
     print(f"Perplexity: {ppl:.2f}")
 
+    if run_gym:
+        rewards, responses = run_gym_autonomous_trainer(TrainerConfig())
+        print("Gym episode returns:", rewards)
+        print("Sample responses:", responses)
+
     # Prompt optimizers
     base_prompt = "Summarize the research article:"
     optim = PromptOptimizer("distilgpt2")
@@ -120,4 +130,14 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the ultimate workflow demo.")
+    parser.add_argument(
+        "--run-gym",
+        action="store_true",
+        help="Launch the gym autonomous trainer after the training demo.",
+    )
+    args = parser.parse_args()
+
+    main(run_gym=args.run_gym)


### PR DESCRIPTION
## Summary
- add `simulation_lab/gym_autonomous_trainer.py` to train GPT-2 as a policy/value head in a Gym environment while streaming rewards and responses through `RealTimeDataAbsorber`
- hook optional `--run-gym` flag into `ultimate_workflow.py` to launch the trainer and display episode returns and sample responses
- document the autonomous Gym trainer and list gym as a requirement

## Testing
- `pip install gym`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688efd889bb48331b0e826599161e31b