### PR TITLE
Implement configurable premium RL workflow with feedback

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,7 @@ rag:
   memory_budget: 50000
 pc:
   context_window: 32
+workflow:
+  enable_absorber: true
+  enable_rl_trainer: true
+  enable_evaluator: true

--- a/premium_workflow.py
+++ b/premium_workflow.py
@@ -1,90 +1,123 @@
 from __future__ import annotations
 
-"""Comprehensive workflow demonstrating all modules."""
+"""End-to-end workflow tying together real-time absorption, RL training and
+language model querying.
 
+This module launches :class:`RealTimeDataAbsorber`, loads a GPT-2 style model
+from the HuggingFace Hub and optionally kicks off a tiny Gym training loop.  A
+``RubricGrader`` can be used to score model responses which are then fed back as
+additional rewards for reinforcement learning.  The behaviour of the workflow is
+controlled via ``config.yaml`` allowing users to enable or disable the absorber,
+trainer or evaluator.
+
+The script exposes a small CLI entry point:
+
+``python premium_workflow.py --gym --benchmark sprout-agi``
+
+Running with ``--gym`` executes the Gym trainer while ``--benchmark`` simply
+prints the benchmark name, acting as a placeholder for future integrations.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import argparse
 import torch
+import yaml
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from research_workflow.topic_selector import TopicSelector
-from digital_literacy.source_evaluator import SourceEvaluator
-from simulation_lab.experiment_simulator import ExperimentSimulator
 from assessment.rubric_grader import RubricGrader
-from security.auth_and_ethics import AuthAndEthics
-from data.dataset_loader import load_and_tokenize
-from train.trainer import TrainingConfig, train_model
-from eval.language_model_evaluator import evaluate_perplexity
-from analysis.dataset_analyzer import analyze_tokenized_dataset
-from analysis.prompt_optimizer import PromptOptimizer
+from simulation_lab.gym_autonomous_trainer import (
+    TrainerConfig,
+    run_gym_autonomous_trainer,
+)
 
 
-def main() -> None:
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    print(f"Using device: {device}")
+MODEL_NAME = "ayjays132/NeuroReasoner-1-NR-1"
 
-    # Initialize modules
-    topic_selector = TopicSelector(device=device)
-    source_evaluator = SourceEvaluator(device=device)
-    experiment_simulator = ExperimentSimulator(device=device)
-    rubric_grader = RubricGrader(device=device)
-    auth_ethics = AuthAndEthics(device=device)
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from RealTimeDataAbsorber import RealTimeDataAbsorber
 
-    # Dataset loading and analysis
-    print("\n=== Dataset Loading & Analysis ===")
-    tokenized_ds = load_and_tokenize("ag_news", "train[:50]", "distilgpt2")
-    stats = analyze_tokenized_dataset(tokenized_ds, max_samples=50)
-    print(f"Dataset stats: {stats}")
 
-    # Quick training demo
-    print("\n=== Training Demo ===")
-    cfg = TrainingConfig(
-        model_name="distilgpt2",
-        dataset_name="ag_news",
-        train_split="train[:10]",
-        eval_split="test[:10]",
-        epochs=1,
-        batch_size=2,
-        output_dir="./demo_model",
+def _load_config(path: str = "config.yaml") -> Dict[str, Any]:
+    """Load YAML configuration."""
+
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def query_model(
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    prompt: str,
+    device: torch.device,
+) -> str:
+    """Generate a response for ``prompt`` using ``model``."""
+
+    inputs = tokenizer(prompt, return_tensors="pt").to(device)
+    outputs = model.generate(
+        **inputs,
+        max_length=inputs["input_ids"].shape[1] + 20,
+        do_sample=True,
+        pad_token_id=tokenizer.eos_token_id,
     )
-    train_model(cfg)
-
-    # Evaluate perplexity
-    ppl = evaluate_perplexity("distilgpt2", "ag_news", split="test[:10]")
-    print(f"Perplexity on small set: {ppl:.2f}")
-
-    # Prompt optimization example
-    optimizer = PromptOptimizer("distilgpt2")
-    best_prompt = optimizer.optimize_prompt("Summarize the research article:")
-    print(f"Optimized prompt: {best_prompt}")
-
-    # Topic suggestion and question validation
-    print("\n=== Research Workflow ===")
-    topic = topic_selector.suggest_topic("machine learning for health")
-    print(f"Suggested topic: {topic}")
-    question = "How can ML improve early disease detection?"
-    print(f"Valid question: {topic_selector.validate_question(question)}")
-
-    # Source evaluation
-    print("\n=== Source Evaluation ===")
-    result = source_evaluator.evaluate_source("https://example.com")
-    print(result)
-
-    # Simulation lab
-    print("\n=== Simulation Lab ===")
-    positions = experiment_simulator.run_physics_simulation(0.0, 5.0, 5, 0.1)
-    print(f"Positions: {positions.tolist()}")
-
-    # Rubric grading
-    print("\n=== Rubric Grading ===")
-    rubric = {"Quality": {"expected_content": "Detailed study", "max_score": 5}}
-    grades = rubric_grader.grade_submission("A short study.", rubric)
-    print(grades)
-
-    # Authentication and ethics
-    print("\n=== Security Module ===")
-    auth_ethics.register_user("demo", "pass", "researcher")
-    print(auth_ethics.authenticate_user("demo", "pass"))
-    auth_ethics.flag_ethical_concern("Test flag")
-    print(auth_ethics.get_ethical_flags())
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
 
 
-if __name__ == "__main__":
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Premium NeuroFlux workflow")
+    parser.add_argument("--gym", action="store_true", help="run Gym RL trainer")
+    parser.add_argument(
+        "--benchmark", type=str, default="", help="optional benchmark tag"
+    )
+    args = parser.parse_args(argv)
+
+    cfg = _load_config()
+    wf_cfg = cfg.get("workflow", {})
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    absorber: Optional["RealTimeDataAbsorber"] = None
+    if wf_cfg.get("enable_absorber", True):
+        from RealTimeDataAbsorber import RealTimeDataAbsorber
+
+        absorber = RealTimeDataAbsorber(
+            model_config={}, settings={"db_path": cfg["paths"]["db_path"]}
+        )
+
+    tokenizer: Optional[AutoTokenizer] = None
+    model: Optional[AutoModelForCausalLM] = None
+    if wf_cfg.get("enable_rl_trainer", True) or wf_cfg.get("enable_evaluator", True):
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+        model = AutoModelForCausalLM.from_pretrained(MODEL_NAME).to(device)
+
+    evaluator_fn = None
+    if wf_cfg.get("enable_evaluator", True):
+        grader = RubricGrader(device=device)
+        rubric = {"quality": {"expected_content": "helpful", "max_score": 1}}
+
+        def evaluator_fn(text: str) -> float:
+            scores = grader.grade_submission(text, rubric)
+            return float(scores["quality"]["score"])
+
+    if args.gym and wf_cfg.get("enable_rl_trainer", True):
+        trainer_cfg = TrainerConfig(model_name=MODEL_NAME)
+        run_gym_autonomous_trainer(
+            trainer_cfg, absorber=absorber, evaluator=evaluator_fn
+        )
+
+    if model is not None and tokenizer is not None:
+        response = query_model(model, tokenizer, "Hello, researcher!", device)
+        print(f"Model response: {response}")
+        if absorber is not None:
+            absorber.absorb_data(response, "text", source="query")
+
+    if absorber is not None:
+        absorber.log_performance_metrics()
+
+    if args.benchmark:
+        print(f"Benchmark requested: {args.benchmark}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+


### PR DESCRIPTION
## Summary
- Add `workflow` toggles in `config.yaml` to enable or disable the real-time absorber, RL trainer, and evaluator.
- Rewrite `premium_workflow.py` to load the NeuroReasoner GPT-2 model, start Gym training, query prompts, and wire in `RubricGrader` feedback, with a CLI entry point.
- Extend Gym autonomous trainer to accept an external absorber and optional evaluator for reward shaping.
- Add unit test ensuring the premium workflow initializes components and logs metrics.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1c8438b48331ac579c012c32ca74