### PR TITLE
Enable configurable RL training workflow

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,7 @@ rag:
   memory_budget: 50000
 pc:
   context_window: 32
+workflow:
+  absorber: true
+  rl_trainer: true
+  evaluator: true

--- a/premium_workflow.py
+++ b/premium_workflow.py
@@ -2,8 +2,17 @@ from __future__ import annotations
 
 """Comprehensive workflow demonstrating all modules."""
 
+import argparse
+from queue import Queue
+import yaml
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from RealTimeDataAbsorber import RealTimeDataAbsorber
+from simulation_lab.gym_autonomous_trainer import (
+    TrainerConfig,
+    run_gym_autonomous_trainer,
+)
 from research_workflow.topic_selector import TopicSelector
 from digital_literacy.source_evaluator import SourceEvaluator
 from simulation_lab.experiment_simulator import ExperimentSimulator
@@ -16,7 +25,9 @@ from analysis.dataset_analyzer import analyze_tokenized_dataset
 from analysis.prompt_optimizer import PromptOptimizer
 
 
-def main() -> None:
+def run_research_workflow() -> None:
+    """Original demonstration workflow showing core components."""
+
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print(f"Using device: {device}")
 
@@ -84,6 +95,77 @@ def main() -> None:
     print(auth_ethics.authenticate_user("demo", "pass"))
     auth_ethics.flag_ethical_concern("Test flag")
     print(auth_ethics.get_ethical_flags())
+
+
+def run_autonomous_pipeline(env_name: str, cfg: dict) -> None:
+    """Run RL training with feedback and optional components."""
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    use_absorber = cfg.get("absorber", True)
+    use_trainer = cfg.get("rl_trainer", True)
+    use_evaluator = cfg.get("evaluator", True)
+
+    absorber: RealTimeDataAbsorber | None = None
+    if use_absorber:
+        metrics_q: Queue = Queue()
+        absorber = RealTimeDataAbsorber(model_config={}, metrics_queue=metrics_q)
+        absorber.start_absorption()
+
+    tokenizer = AutoTokenizer.from_pretrained("ayjays132/NeuroReasoner-1-NR-1")
+    model = AutoModelForCausalLM.from_pretrained(
+        "ayjays132/NeuroReasoner-1-NR-1"
+    ).to(device)
+
+    responses: list[str] = []
+    episode_returns: list[float] = []
+
+    if use_trainer:
+        gym_cfg = TrainerConfig(env_name=env_name)
+        episode_returns, responses = run_gym_autonomous_trainer(gym_cfg)
+
+    # Periodic user prompts
+    prompts = ["Describe the research goal."]
+    for prompt in prompts:
+        inputs = tokenizer(prompt, return_tensors="pt").to(device)
+        out_ids = model.generate(
+            **inputs, max_length=inputs["input_ids"].shape[1] + 20, pad_token_id=tokenizer.eos_token_id
+        )
+        text = tokenizer.decode(out_ids[0], skip_special_tokens=True)
+        responses.append(text)
+        if absorber is not None:
+            absorber.absorb_data(text, "text", source="prompt", priority=1)
+
+    if use_evaluator and responses:
+        grader = RubricGrader(device=device)
+        rubric = {"Quality": {"expected_content": "research", "max_score": 5}}
+        feedback_scores = []
+        for resp in responses:
+            grade = grader.grade_submission(resp, rubric)["Quality"]["score"]
+            feedback_scores.append(grade)
+        if episode_returns:
+            episode_returns = [r + sum(feedback_scores) for r in episode_returns]
+        print(f"Feedback scores: {feedback_scores}")
+
+    print(f"Episode rewards: {episode_returns}")
+
+    if absorber is not None:
+        absorber.stop_absorption()
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entrypoint for running premium workflow pipelines."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gym", action="store_true", help="run gym RL trainer")
+    parser.add_argument("--benchmark", default="CartPole-v1", help="gym benchmark")
+    args = parser.parse_args(argv)
+
+    run_research_workflow()
+
+    if args.gym:
+        with open("config.yaml", "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f).get("workflow", {})
+        run_autonomous_pipeline(args.benchmark, config)
 
 
 if __name__ == "__main__":

--- a/tests/test_premium_workflow.py
+++ b/tests/test_premium_workflow.py
@@ -1,12 +1,57 @@
+import importlib
+import sys
 import types
 from unittest.mock import MagicMock
-
 import torch
 
-import premium_workflow
+
+def _load_workflow(monkeypatch):
+    for name in [
+        "cv2",
+        "aiohttp",
+        "psutil",
+    ]:
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    ws_mod = types.ModuleType("interface.ws_server")
+    ws_mod.run_ws_server = MagicMock()
+    monkeypatch.setitem(sys.modules, "interface.ws_server", ws_mod)
+    faiss_mod = types.ModuleType("faiss")
+    faiss_mod.__spec__ = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "faiss", faiss_mod)
+    tv_mod = types.ModuleType("torchvision")
+    tv_mod.__spec__ = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "torchvision", tv_mod)
+    tv_t_mod = types.ModuleType("torchvision.transforms")
+    tv_t_mod.__spec__ = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "torchvision.transforms", tv_t_mod)
+    sf_mod = types.ModuleType("soundfile")
+    sf_mod.__spec__ = types.SimpleNamespace()
+    sf_mod.__libsndfile_version__ = "1.0.31"
+    monkeypatch.setitem(sys.modules, "soundfile", sf_mod)
+    orig_find = importlib.util.find_spec
+    monkeypatch.setattr(
+        importlib.util,
+        "find_spec",
+        lambda name, package=None: types.SimpleNamespace()
+        if name == "soundfile"
+        else orig_find(name, package),
+    )
+    fake_cluster = types.ModuleType("sklearn.cluster")
+    fake_cluster.DBSCAN = MagicMock()
+    fake_cluster.KMeans = MagicMock()
+    monkeypatch.setitem(sys.modules, "sklearn.cluster", fake_cluster)
+    fake_preproc = types.ModuleType("sklearn.preprocessing")
+    fake_preproc.StandardScaler = MagicMock()
+    fake_preproc.KernelCenterer = MagicMock()
+    monkeypatch.setitem(sys.modules, "sklearn.preprocessing", fake_preproc)
+    fake_dq = types.ModuleType("analysis.dataset_quality")
+    fake_dq.score_record = MagicMock(return_value=(1.0, []))
+    monkeypatch.setitem(sys.modules, "analysis.dataset_quality", fake_dq)
+    return importlib.import_module("premium_workflow")
 
 
 def test_main_runs(monkeypatch):
+    premium_workflow = _load_workflow(monkeypatch)
     monkeypatch.setattr(premium_workflow, "load_and_tokenize", lambda *a, **k: [])
     monkeypatch.setattr(
         premium_workflow, "analyze_tokenized_dataset", lambda *a, **k: {"samples": 0}
@@ -49,4 +94,119 @@ def test_main_runs(monkeypatch):
         premium_workflow.AuthAndEthics, "get_ethical_flags", lambda self: []
     )
 
-    premium_workflow.main()
+    premium_workflow.main([])
+
+
+def test_autonomous_pipeline_runs(monkeypatch, capsys):
+    premium_workflow = _load_workflow(monkeypatch)
+
+    # Patch heavy functions as in main run
+    monkeypatch.setattr(premium_workflow, "load_and_tokenize", lambda *a, **k: [])
+    monkeypatch.setattr(
+        premium_workflow, "analyze_tokenized_dataset", lambda *a, **k: {"samples": 0}
+    )
+    monkeypatch.setattr(premium_workflow, "train_model", lambda cfg: None)
+    monkeypatch.setattr(premium_workflow, "evaluate_perplexity", lambda *a, **k: 0.0)
+    monkeypatch.setattr(
+        premium_workflow.TopicSelector, "suggest_topic", lambda self, x: "Topic"
+    )
+    monkeypatch.setattr(
+        premium_workflow.TopicSelector, "validate_question", lambda self, q: True
+    )
+    monkeypatch.setattr(
+        premium_workflow.SourceEvaluator,
+        "evaluate_source",
+        lambda self, url: {"credibility": "high"},
+    )
+    monkeypatch.setattr(
+        premium_workflow.ExperimentSimulator,
+        "run_physics_simulation",
+        lambda self, *a, **k: torch.tensor([0.0]),
+    )
+    monkeypatch.setattr(
+        premium_workflow.RubricGrader,
+        "grade_submission",
+        lambda self, t, r: {"Quality": {"score": 5, "max_score": 5}},
+    )
+    monkeypatch.setattr(
+        premium_workflow.AuthAndEthics, "register_user", lambda self, *a: True
+    )
+    monkeypatch.setattr(
+        premium_workflow.AuthAndEthics, "authenticate_user", lambda self, *a: True
+    )
+    monkeypatch.setattr(
+        premium_workflow.AuthAndEthics,
+        "flag_ethical_concern",
+        lambda self, *a, **k: None,
+    )
+    monkeypatch.setattr(
+        premium_workflow.AuthAndEthics, "get_ethical_flags", lambda self: []
+    )
+
+    class DummyAbsorber:
+        started = False
+
+        def __init__(self, *a, **k):
+            pass
+
+        def start_absorption(self):
+            DummyAbsorber.started = True
+
+        def stop_absorption(self):
+            pass
+
+        def absorb_data(self, *a, **k):
+            pass
+
+    class DummyTok:
+        eos_token_id = 0
+
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            class Batch(dict):
+                def to(self, device):
+                    return self
+
+            return Batch({"input_ids": torch.tensor([[0]])})
+
+        def decode(self, ids, skip_special_tokens=True):
+            return "resp"
+
+        def to(self, device):
+            return self
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+        def to(self, device):
+            return self
+
+        def generate(self, **kwargs):
+            return torch.tensor([[0]])
+
+    class DummyGrader:
+        def __init__(self, *a, **k):
+            pass
+
+        def grade_submission(self, text, rubric):
+            return {"Quality": {"score": 1, "max_score": 5}}
+
+    monkeypatch.setattr(premium_workflow, "RealTimeDataAbsorber", DummyAbsorber)
+    monkeypatch.setattr(premium_workflow, "AutoModelForCausalLM", DummyModel)
+    monkeypatch.setattr(premium_workflow, "AutoTokenizer", DummyTok)
+    monkeypatch.setattr(
+        premium_workflow,
+        "run_gym_autonomous_trainer",
+        lambda cfg: ([1.0], ["hi"]),
+    )
+    monkeypatch.setattr(premium_workflow, "RubricGrader", DummyGrader)
+
+    premium_workflow.main(["--gym", "--benchmark", "sprout-agi"])
+    captured = capsys.readouterr()
+    assert "Episode rewards" in captured.out
+    assert DummyAbsorber.started


### PR DESCRIPTION
## Summary
- integrate RealTimeDataAbsorber and Gym RL loop with GPT-2 model in `premium_workflow`
- add workflow toggles to `config.yaml`
- test autonomous pipeline initialization and logging

## Testing
- `pytest tests/test_premium_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f25dd74b08331b10d929257dd451d