### PR TITLE
feat: streamline premium workflow and benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,54 @@
-# NeuroFluxLIVE Premium Workflow 🚀
+# 🌐 NeuroFluxLIVE Premium Workflow
 
-NeuroFluxLIVE provides a modular research sandbox for continual-learning language models.  
-The `premium_workflow.py` script weaves data ingestion, training, evaluation and reinforcement learning into a single pipeline.
+**NeuroFluxLIVE** fuses real‑time data absorption, language model fine‑tuning and reinforcement learning into a single, plug‑and‑play research sandbox.  The `premium_workflow.py` entrypoint runs everything: dataset ingestion, model training, prompt evaluation and optional Gym simulations.
 
-## Installation
+## ⚙️ Installation
 ```bash
 pip install -r requirements.txt
 pip install -e .
 ```
+The package exposes a console script named `premium_workflow` for immediate use after installation.
 
-## Premium Workflow Usage
-Run the end-to-end workflow:
+## 🚀 Quick Start
+Run the full demonstration pipeline:
 ```bash
 premium_workflow
 ```
+Add flags to enable extra benchmarks:
+- `--sprout-benchmark` – fine‑tune GPT‑style models on the [Sprout‑AGI](https://huggingface.co/datasets/ayjays132/Sprout-AGI) reasoning dataset.
+- `--gym` `--benchmark CartPole-v1` – launch the autonomous RL trainer alongside language prompting.
 
-### Sprout‑AGI Benchmark 🌱
-Fine‑tune any causal language model on the [Sprout‑AGI](https://huggingface.co/datasets/ayjays132/Sprout-AGI) reasoning dataset and compare perplexity before and after training.
-```bash
-premium_workflow --sprout-benchmark
-```
-A quick baseline with `distilgpt2` on a tiny subset reports a perplexity around **194.15** before training.  
-Fine‑tuning steps executed by the command will lower this value.
+## 🌱 Sprout‑AGI Benchmark
+The benchmark measures perplexity before and after a short fine‑tuning run.  Example with `gpt2`:
 
-### Gym RL Demo 🕹️
-Evaluate autonomous learning in a Gym environment while the model continues to answer prompts:
+| Model | Baseline PPL | Tuned PPL |
+|------|--------------|-----------|
+| gpt2 | 133.08 | 18.44 |
+
+Prompt quality also improves.  Given the prompt **“The future of AI is”**:
+
+| Stage | Generated Continuation |
+|-------|-----------------------|
+| Baseline | *The future of AI is uncertain. The future of AI is uncertain.* |
+| Fine‑tuned | *The future of AI is a complex and complex subject matter. We will continue to explore the potential of AI to improve human understanding.* |
+
+## 🕹️ Gym RL Demo
 ```bash
 premium_workflow --gym --benchmark CartPole-v1
 ```
-Episode returns and textual feedback are printed after each run.
+The workflow trains an agent in the environment while periodically querying the language model.  Episode returns are printed together with rubric‑based feedback scores.
 
-## Metrics
-| Experiment | Metric | Example Result |
-|------------|--------|----------------|
-| Sprout‑AGI baseline | Perplexity ↓ | 194.15 |
-| CartPole demo | Avg. return ↑ | printed at runtime |
+## 🧩 Module Showcase
+`premium_workflow.py` orchestrates every module:
+- **Data ingestion** via `RealTimeDataAbsorber` (optional).
+- **Language model training** with `train.trainer`.
+- **Evaluation** using `eval.language_model_evaluator` and custom rubric grading.
+- **Simulation & RL** through `simulation_lab.gym_autonomous_trainer`.
 
-## Testing
-Run the test suite before committing changes:
+## ✅ Testing
 ```bash
 pytest
 ```
 
-## License
+## 📄 License
 Research use only.


### PR DESCRIPTION
## Summary
- make RealTimeDataAbsorber optional so the premium workflow can run even when cv2 is missing
- document new Sprout‑AGI benchmark results and quick start usage in a refreshed README

## Testing
- `pytest`
- `python premium_workflow.py --sprout-benchmark`


------
https://chatgpt.com/codex/tasks/task_e_688f3a9a230483318f1549875cf9b594