### PR TITLE
Refine Sprout-AGI benchmark and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌟 NeuroFluxLIVE Premium Pipeline
 
-**NeuroFluxLIVE** merges streaming data absorption, language model fine‑tuning and reinforcement learning into one seamless workflow. The heart of the system is [`premium_workflow.py`](premium_workflow.py), exposed as a console script called `premium_workflow` after installation.
+**NeuroFluxLIVE** combines streaming data absorption, on-the-fly fine-tuning, and reinforcement learning so a model can keep learning while it serves responses. The main entrypoint is [`premium_workflow.py`](premium_workflow.py), installed as the `premium_workflow` console script.
 
 ## 📦 Installation
 ```bash
@@ -8,41 +8,41 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
-## 🏁 Quick Start
-Run the default demonstration:
+## 🚀 Using the Premium Workflow
+Run the integrated demonstration:
 ```bash
 premium_workflow
 ```
 
-### Sprout‑AGI Benchmark
-Fine‑tune any GPT‑style model on the [Sprout‑AGI](https://huggingface.co/datasets/ayjays132/Sprout-AGI) reasoning set and view perplexity shifts and prompt quality.
+### 🔬 Sprout-AGI Benchmark
+Fine-tune any GPT-style model against the [Sprout-AGI](https://huggingface.co/datasets/ayjays132/Sprout-AGI) reasoning set:
 ```bash
 premium_workflow --sprout-benchmark --model ayjays132/NeuroReasoner-1-NR-1 --prompt "The future of AI is"
 ```
-Results with `ayjays132/NeuroReasoner-1-NR-1` on a small sample:
+The command reports baseline and tuned perplexity and, if a prompt is supplied, compares generations. Using `ayjays132/NeuroReasoner-1-NR-1` on a four-example subset yields:
 
 | Model | Baseline PPL | Tuned PPL |
 |-------|--------------|-----------|
-| ayjays132/NeuroReasoner-1-NR-1 | 24.79 | 13.94 |
+| ayjays132/NeuroReasoner-1-NR-1 | 221.51 | 15.43 |
 
 Prompt **"The future of AI is"**:
 
 | Stage | Continuation |
 |-------|-------------|
-| Baseline | *The future of AI is uncertain, with growing concerns about bias and privacy. What strategies can be implemented to mitigate these risks?* |
-| Tuned | *The future of AI is a complex, interdependent process that requires thoughtful planning and continuous iteration.* |
+| Baseline | The future of AI is in its ability to learn from human experience and adapt. This reflection illustrates that by integrating... |
+| Tuned | The future of AI is uncertain, but it’s essential for modern life. 🤖💧 |
 
-### Autonomous Gym Training
+### 🕹️ Autonomous Gym Training
 ```bash
 premium_workflow --gym --benchmark CartPole-v1
 ```
-Trains a lightweight policy head inside a Gym environment while querying the language model and streaming metrics.
+Trains a lightweight policy head in a Gym environment while simultaneously querying the language model.
 
-## 🧪 Component Overview
-- **RealTimeDataAbsorber** for live ingestion.
-- **train.trainer** for supervised fine‑tuning.
-- **eval.language_model_evaluator** for perplexity metrics.
-- **simulation_lab.gym_autonomous_trainer** for RL demos.
+## 🧩 Key Modules
+- **RealTimeDataAbsorber** – streams incoming data to the model.
+- **train.trainer** – supervised fine-tuning utilities.
+- **eval.language_model_evaluator** – quick perplexity evaluation.
+- **simulation_lab.gym_autonomous_trainer** – RL experiments.
 
 ## 🛠️ Development & Testing
 ```bash

--- a/premium_workflow.py
+++ b/premium_workflow.py
@@ -250,6 +250,7 @@ def benchmark_sprout_agi(
         per_device_train_batch_size=2,
         logging_steps=10,
         report_to="none",
+        save_strategy="no",  # avoid writing large checkpoint files during quick benchmarks
     )
     trainer = Trainer(
         model=model, args=args, train_dataset=train_tok, eval_dataset=eval_tok


### PR DESCRIPTION
## Summary
- disable checkpoint saving during Sprout-AGI benchmark to keep quick runs light
- refresh README around `premium_workflow` with new benchmark metrics and usage docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fcdce41b0833182d6e0091deb97bf