### PR TITLE
Add premium pipeline helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ premium_workflow --sprout-benchmark --model ayjays132/NeuroReasoner-1-NR-1 --pro
 ```
 | Model | Baseline PPL | Tuned PPL |
 |-------|--------------|-----------|
-| ayjays132/NeuroReasoner-1-NR-1 | 66.44 | 8.94 |
+| ayjays132/NeuroReasoner-1-NR-1 | 221.51 | 15.43 |
 
 ### CartPole Reinforcement Learning
 ```bash
@@ -45,11 +45,20 @@ Average reward ≈ 15.95 over three episodes.
 ```bash
 python - <<'PY'
 from premium_workflow import run_evolutionary_learner
-run_evolutionary_learner('Hello world', 'ayjays132/NeuroReasoner-1-NR-1', generations=1, population=5)
+run_evolutionary_learner('Hello world', 'gpt2', generations=1, population=2)
 PY
 ```
-Best fitness −13.98 with evolved continuation:
-> Hello world, where every decision you make is a!ial-Tribute to the!isphere of!ial
+Best fitness −5.86 with evolved continuation:
+> Hello world, I'm not sure what to say.
+
+### Full Premium Pipeline
+Run research tools, RL loop and evolutionary search in one call:
+```bash
+python - <<'PY'
+from premium_workflow import run_premium_workflow
+run_premium_workflow(prompt="The sky is blue because")
+PY
+```
 
 ## 🧪 Testing
 ```bash

--- a/premium_workflow.py
+++ b/premium_workflow.py
@@ -249,6 +249,27 @@ def run_autonomous_pipeline(env_name: str, cfg: dict) -> None:
         absorber.stop_absorption()
 
 
+def run_premium_workflow(
+    prompt: str,
+    model_name: str = "ayjays132/NeuroReasoner-1-NR-1",
+    env_name: str = "CartPole-v1",
+) -> None:
+    """Execute research, RL and evolutionary steps sequentially.
+
+    This helper shows how all premium components can be chained together for
+    a single experiment.  It simply invokes :func:`run_research_workflow`, the
+    RL pipeline via :func:`run_autonomous_pipeline` and finally the
+    evolutionary learner.  The individual functions remain unchanged so the
+    caller can still run them separately if desired.
+    """
+
+    run_research_workflow()
+    with open("config.yaml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f).get("workflow", {})
+    run_autonomous_pipeline(env_name, cfg)
+    run_evolutionary_learner(prompt=prompt, model_name=model_name)
+
+
 def benchmark_sprout_agi(
     model_name: str = "gpt2",
     train_samples: int = 32,
@@ -422,6 +443,7 @@ __all__ = [
     "run_research_workflow",
     "run_autonomous_pipeline",
     "run_evolutionary_learner",
+    "run_premium_workflow",
     "benchmark_sprout_agi",
     "main",
 ]


### PR DESCRIPTION
## Summary
- chain research, RL, and evolutionary steps with new `run_premium_workflow`
- document Sprout-AGI benchmark and pipeline usage in README

## Testing
- `PYTHONPATH=. pytest`
- `python - <<'PY'
from premium_workflow import run_evolutionary_learner
run_evolutionary_learner(prompt='Hello world', model_name='gpt2', generations=1, population=2)
PY`
- `python - <<'PY'
from premium_workflow import benchmark_sprout_agi
benchmark_sprout_agi(model_name='ayjays132/NeuroReasoner-1-NR-1', train_samples=4, eval_samples=2, prompt='The sky is blue because')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6893bba0b0c48331afb1370a31df672a