### PR TITLE
feat: default to NeuroReasoner model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌟 NeuroFluxLIVE Premium Workflow
 
-NeuroFluxLIVE unifies fine‑tuning, reinforcement learning and evolutionary search into a single always‑on pipeline. The `premium_workflow` CLI lets any Hugging Face causal model learn from streaming experience while still answering user prompts.
+NeuroFluxLIVE unifies fine‑tuning, reinforcement learning and evolutionary search into a single always‑on pipeline. The `premium_workflow` CLI ships with `ayjays132/NeuroReasoner-1-NR-1` as the default GPT‑2‑style backbone but accepts any Hugging Face causal model, learning from streaming experience while still answering user prompts.
 
 ## 🚀 Features
 - **Model agnostic:** supply any Hugging Face model with `--model`.
@@ -15,7 +15,7 @@ pip install -e .
 ```
 
 ## 💡 Quick Start
-Run the full demo:
+Run the full demo (defaults to `ayjays132/NeuroReasoner-1-NR-1`):
 ```bash
 premium_workflow
 ```
@@ -24,6 +24,8 @@ premium_workflow
 ```bash
 premium_workflow --sprout-benchmark --model ayjays132/NeuroReasoner-1-NR-1 --prompt "Hello world"
 ```
+Example run:
+
 | Model | Baseline PPL | Tuned PPL |
 |-------|--------------|-----------|
 | ayjays132/NeuroReasoner-1-NR-1 | 221.51 | 15.43 |
@@ -45,7 +47,7 @@ Average reward ≈ 15.95 over three episodes.
 ```bash
 python - <<'PY'
 from premium_workflow import run_evolutionary_learner
-run_evolutionary_learner('Hello world', 'gpt2', generations=1, population=2)
+run_evolutionary_learner('Hello world', 'ayjays132/NeuroReasoner-1-NR-1', generations=1, population=2)
 PY
 ```
 Best fitness −5.86 with evolved continuation:

--- a/premium_workflow.py
+++ b/premium_workflow.py
@@ -74,17 +74,19 @@ def run_research_workflow() -> None:
 
     # Dataset loading and analysis
     print("\n=== Dataset Loading & Analysis ===")
-    tokenized_ds = load_and_tokenize("ag_news", "train[:50]", "distilgpt2")
+    tokenized_ds = load_and_tokenize(
+        "ayjays132/Sprout-AGI", "train[:50]", "ayjays132/NeuroReasoner-1-NR-1"
+    )
     stats = analyze_tokenized_dataset(tokenized_ds, max_samples=50)
     print(f"Dataset stats: {stats}")
 
     # Quick training demo
     print("\n=== Training Demo ===")
     cfg = TrainingConfig(
-        model_name="distilgpt2",
-        dataset_name="ag_news",
+        model_name="ayjays132/NeuroReasoner-1-NR-1",
+        dataset_name="ayjays132/Sprout-AGI",
         train_split="train[:10]",
-        eval_split="test[:10]",
+        eval_split="train[:10]",
         epochs=1,
         batch_size=2,
         output_dir="./demo_model",
@@ -92,11 +94,13 @@ def run_research_workflow() -> None:
     train_model(cfg)
 
     # Evaluate perplexity
-    ppl = evaluate_perplexity("distilgpt2", "ag_news", split="test[:10]")
+    ppl = evaluate_perplexity(
+        "ayjays132/NeuroReasoner-1-NR-1", "ayjays132/Sprout-AGI", split="train[:10]"
+    )
     print(f"Perplexity on small set: {ppl:.2f}")
 
     # Prompt optimization example
-    optimizer = PromptOptimizer("distilgpt2")
+    optimizer = PromptOptimizer("ayjays132/NeuroReasoner-1-NR-1")
     best_prompt = optimizer.optimize_prompt("Summarize the research article:")
     print(f"Optimized prompt: {best_prompt}")
 
@@ -133,7 +137,7 @@ def run_research_workflow() -> None:
 
 def run_evolutionary_learner(
     prompt: str,
-    model_name: str = "gpt2",
+    model_name: str = "ayjays132/NeuroReasoner-1-NR-1",
     generations: int = 2,
     population: int = 10,
 ) -> None:
@@ -271,7 +275,7 @@ def run_premium_workflow(
 
 
 def benchmark_sprout_agi(
-    model_name: str = "gpt2",
+    model_name: str = "ayjays132/NeuroReasoner-1-NR-1",
     train_samples: int = 32,
     eval_samples: int = 16,
     prompt: str | None = None,
@@ -403,7 +407,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "--model",
-        default="gpt2",
+        default="ayjays132/NeuroReasoner-1-NR-1",
         help="model name for the Sprout-AGI benchmark",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default premium workflow to `ayjays132/NeuroReasoner-1-NR-1` and Sprout‑AGI dataset
- update CLI and examples for new baseline model

## Testing
- `pytest -q` *(fails: AttributeError: module 'torch' has no attribute 'uint64')*

------
https://chatgpt.com/codex/tasks/task_e_6893fc4761288331a1e0fb4735c0ee6c